### PR TITLE
PHPdoc

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -30,7 +30,7 @@ class Dispatcher implements MiddlewareInterface, RequestHandlerInterface
     private $next;
 
     /**
-     * @param MiddlewareInterface[] $middleware
+     * @param MiddlewareInterface[]|string[]|array[]|Closure[] $middleware
      */
     public function __construct(array $middleware, ContainerInterface $container = null)
     {


### PR DESCRIPTION
The `$middleware` parameter can be one of four types.

My static-analysis software keeps complaining that I'm passing the wrong types to the constructor...