### PR TITLE
Make tests php8 compatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /composer.lock
 /.php_cs.cache
+/.phpunit.result.cache

--- a/tests/FakeMiddleware.php
+++ b/tests/FakeMiddleware.php
@@ -14,7 +14,7 @@ class FakeMiddleware implements MiddlewareInterface
 
     public function __construct($char = '.')
     {
-        $this->char = $char;
+        $this->char = strval($char);
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $next): ResponseInterface


### PR DESCRIPTION
Requires also phpunit ^9 and laminas-diactoros ^2.5 to work on php8.

See #8 for Details