### PR TITLE
Fix: #11 - Add compatibility for PHP 8.4. Drop compatibility with PHP 7.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,41 +1,29 @@
 name: "testing"
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
-    tests:
-        name: Tests
-        runs-on: ubuntu-latest
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    name: Testing PHP ${{ matrix.php-version }} on ${{ matrix.operating-system }}
 
-        strategy:
-            matrix:
-              php:
-                - 7.0
-                - 7.1
-                - 7.2
-                - 7.3
-                - 7.4
-              composer-args: [ "" ]
-              include:
-                - php: 8.0
-                  composer-args: --ignore-platform-reqs
-            fail-fast: false
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-latest']
+        php-version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+      fail-fast: false
 
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
+    steps:
+      - uses: shivammathur/setup-php@master
+        with:
+          php-version: ${{ matrix.php-version }}
+          ini-file: 'development'
+          coverage: xdebug
 
-            - name: Install PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php }}
+      - uses: actions/checkout@v4
 
-            - name: Install dependencies
-              run: composer install --prefer-dist --no-progress --no-suggest ${{ matrix.composer-args }}
+      - run: composer validate
 
-            - name: Tests
-              run: composer test-coverage
+      - run: composer install --no-progress
+
+      - run: composer test-coverage

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,14 @@
         "issues": "https://github.com/oscarotero/dispatcher/issues"
     },
     "require": {
-        "php": "^7.0|^8.0",
+        "php": "7.1 - 8.4",
         "psr/http-server-middleware": "^1.0",
         "psr/container": "^1.0"
     },
     "require-dev": {
         "laminas/laminas-diactoros": "^1.3",
         "friendsofphp/php-cs-fixer": "^2.0",
-        "phpunit/phpunit": ">=6.0"
+        "phpunit/phpunit": "^7.0|^8.0|^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    colors="true"
-    verbose="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false">
-    <testsuites>
-        <testsuite name="All tests">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+  bootstrap="vendor/autoload.php"
+  colors="true"
+>
+  <testsuites>
+    <testsuite name="Unit tests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -32,7 +32,7 @@ class Dispatcher implements MiddlewareInterface, RequestHandlerInterface
     /**
      * @param MiddlewareInterface[]|string[]|array[]|Closure[] $middleware
      */
-    public function __construct(array $middleware, ContainerInterface $container = null)
+    public function __construct(array $middleware, ?ContainerInterface $container = null)
     {
         if (empty($middleware)) {
             throw new LogicException('Empty middleware queue');

--- a/tests/AcceptMatcherTest.php
+++ b/tests/AcceptMatcherTest.php
@@ -4,12 +4,18 @@ declare(strict_types = 1);
 namespace Middleland\Tests;
 
 use Middleland\Matchers\Accept;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Laminas\Diactoros\ServerRequest;
 
+/**
+ * @coversClass Accept
+ */
+#[CoversClass(Accept::class)]
 class AcceptMatcherTest extends TestCase
 {
-    public function pathProvider()
+    public static function pathProvider(): array
     {
         return [
             ['text/html', 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', true],
@@ -20,7 +26,8 @@ class AcceptMatcherTest extends TestCase
     /**
      * @dataProvider pathProvider
      */
-    public function testMatcher(string $pattern, string $accept, bool $valid)
+    #[DataProvider('pathProvider')]
+    public function testMatcher(string $pattern, string $accept, bool $valid): void
     {
         $matcher = new Accept($pattern);
         $request = (new ServerRequest())->withHeader('Accept', $accept);

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -7,13 +7,18 @@ use Datetime;
 use InvalidArgumentException;
 use LogicException;
 use Middleland\Dispatcher;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Laminas\Diactoros\ServerRequest;
 
+/**
+ * @coversClass Dispatcher
+ */
+#[CoversClass(Dispatcher::class)]
 class DispatcherTest extends TestCase
 {
-    public function testEndPointMiddleware()
+    public function testEndPointMiddleware(): void
     {
         $dispatcher = new Dispatcher([
             new FakeEndPointMiddleware(),
@@ -22,7 +27,7 @@ class DispatcherTest extends TestCase
         $this->assertResponse('', $dispatcher(new ServerRequest()));
     }
 
-    public function testMiddleware()
+    public function testMiddleware(): void
     {
         $dispatcher = new Dispatcher([
             new FakeMiddleware(1),
@@ -34,7 +39,7 @@ class DispatcherTest extends TestCase
         $this->assertResponse('321', $dispatcher->dispatch(new ServerRequest()));
     }
 
-    public function testClosure()
+    public function testClosure(): void
     {
         $dispatcher = new Dispatcher([
             function ($request, $next) {
@@ -48,7 +53,7 @@ class DispatcherTest extends TestCase
         $this->assertResponse('hello', $dispatcher->dispatch(new ServerRequest()));
     }
 
-    public function testInnerMiddleware()
+    public function testInnerMiddleware(): void
     {
         $dispatcher = new Dispatcher([
             new FakeMiddleware(1),
@@ -71,7 +76,7 @@ class DispatcherTest extends TestCase
         $this->assertResponse('87654321', $dispatcher->dispatch(new ServerRequest()));
     }
 
-    public function testMatchers()
+    public function testMatchers(): void
     {
         $dispatcher = new Dispatcher([
             new FakeMiddleware(1),
@@ -84,7 +89,7 @@ class DispatcherTest extends TestCase
         $this->assertResponse('431', $dispatcher->dispatch(new ServerRequest([], [], '/world')));
     }
 
-    public function testContainer()
+    public function testContainer(): void
     {
         $dispatcher = new Dispatcher([
             '1',
@@ -97,7 +102,7 @@ class DispatcherTest extends TestCase
         $this->assertResponse('421', $dispatcher->dispatch(new ServerRequest()));
     }
 
-    public function testDispatcherReuse()
+    public function testDispatcherReuse(): void
     {
         $dispatcher1 = new Dispatcher([
             new FakeMiddleware(1),
@@ -118,14 +123,14 @@ class DispatcherTest extends TestCase
         $this->assertResponse('321', $dispatcher1->dispatch(new ServerRequest()));
     }
 
-    public function testEmptyDispatcherException()
+    public function testEmptyDispatcherException(): void
     {
         $this->expectException(LogicException::class);
 
         $dispatcher = new Dispatcher([]);
     }
 
-    public function testExhaustedException()
+    public function testExhaustedException(): void
     {
         $this->expectException(LogicException::class);
 
@@ -137,7 +142,7 @@ class DispatcherTest extends TestCase
         $dispatcher->dispatch(new ServerRequest());
     }
 
-    public function testInvalidMiddlewareException()
+    public function testInvalidMiddlewareException(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -148,7 +153,7 @@ class DispatcherTest extends TestCase
         $dispatcher->dispatch(new ServerRequest());
     }
 
-    public function testInvalidStringMiddlewareException()
+    public function testInvalidStringMiddlewareException(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -159,7 +164,7 @@ class DispatcherTest extends TestCase
         $dispatcher->dispatch(new ServerRequest());
     }
 
-    public function testInvalidMatcherException()
+    public function testInvalidMatcherException(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/PathMatcherTest.php
+++ b/tests/PathMatcherTest.php
@@ -4,12 +4,18 @@ declare(strict_types = 1);
 namespace Middleland\Tests;
 
 use Middleland\Matchers\Path;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Laminas\Diactoros\ServerRequest;
 
+/**
+ * @coversClass Path
+ */
+#[CoversClass(Path::class)]
 class PathMatcherTest extends TestCase
 {
-    public function pathProvider()
+    public static function pathProvider(): array
     {
         return [
             ['/hello', '/hello', true],
@@ -25,7 +31,8 @@ class PathMatcherTest extends TestCase
     /**
      * @dataProvider pathProvider
      */
-    public function testMatcher(string $pattern, string $path, bool $valid)
+    #[DataProvider('pathProvider')]
+    public function testMatcher(string $pattern, string $path, bool $valid): void
     {
         $matcher = new Path($pattern);
         $request = new ServerRequest([], [], $path);

--- a/tests/PatternMatcherTest.php
+++ b/tests/PatternMatcherTest.php
@@ -4,12 +4,18 @@ declare(strict_types = 1);
 namespace Middleland\Tests;
 
 use Middleland\Matchers\Pattern;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Laminas\Diactoros\ServerRequest;
 
+/**
+ * @coversClass Pattern
+ */
+#[CoversClass(Pattern::class)]
 class PatternMatcherTest extends TestCase
 {
-    public function pathProvider()
+    public static function pathProvider(): array
     {
         return [
             ['/hello', '/hello', true],
@@ -30,7 +36,8 @@ class PatternMatcherTest extends TestCase
     /**
      * @dataProvider pathProvider
      */
-    public function testMatcher(string $pattern, string $path, bool $valid, int $flags = 0)
+    #[DataProvider('pathProvider')]
+    public function testMatcher(string $pattern, string $path, bool $valid, int $flags = 0): void
     {
         $matcher = new Pattern($pattern, $flags);
         $request = new ServerRequest([], [], $path);


### PR DESCRIPTION
This change adds compatibility with PHP 8.4.

Specifically, the deprecation notices about "implicit null parameters".  The code has been updated to use "explicit null".

This is a one-line, one-character change.

This fix requires PHP syntax which is not compatible with PHP 7.0, so I have raised the minimum supported version from PHP 7.0 to PHP 7.1.

I've updated the test scripts and CI to work with a wide range of PHP and PHPUNIT versions.  Hence the dupliation in the docblock / attributes.